### PR TITLE
Fix missing setLocalizedName(...) from previous PR

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ enable_junit_testing = false
 show_testing_output = false
 
 # Mod Information
-mod_version = 1.2.0
+mod_version = 1.2.1
 root_package = krelox
 mod_id = metallurgychests
 mod_name = Metallurgy Chests

--- a/src/main/java/krelox/metallurgychests/blocks/BlockBrassChest.java
+++ b/src/main/java/krelox/metallurgychests/blocks/BlockBrassChest.java
@@ -48,6 +48,7 @@ public class BlockBrassChest extends BlockContainer
 	public BlockBrassChest(String name) 
 	{
 		super(Material.IRON);
+		setTranslationKey(name);
 		setRegistryName(name);
 		setCreativeTab(MetallurgyTabs.tabSpecial);
 		setHardness(6.0f);

--- a/src/main/java/krelox/metallurgychests/blocks/BlockElectrumChest.java
+++ b/src/main/java/krelox/metallurgychests/blocks/BlockElectrumChest.java
@@ -48,6 +48,7 @@ public class BlockElectrumChest extends BlockContainer
 	public BlockElectrumChest(String name) 
 	{
 		super(Material.IRON);
+		setTranslationKey(name);
 		setRegistryName(name);
 		setCreativeTab(MetallurgyTabs.tabSpecial);
 		setHardness(6.0f);

--- a/src/main/java/krelox/metallurgychests/blocks/BlockPlatinumChest.java
+++ b/src/main/java/krelox/metallurgychests/blocks/BlockPlatinumChest.java
@@ -48,6 +48,7 @@ public class BlockPlatinumChest extends BlockContainer
 	public BlockPlatinumChest(String name) 
 	{
 		super(Material.IRON);
+		setTranslationKey(name);
 		setRegistryName(name);
 		setCreativeTab(MetallurgyTabs.tabSpecial);
 		setHardness(6.0f);

--- a/src/main/java/krelox/metallurgychests/blocks/BlockRubraciumChest.java
+++ b/src/main/java/krelox/metallurgychests/blocks/BlockRubraciumChest.java
@@ -48,6 +48,7 @@ public class BlockRubraciumChest extends BlockContainer
 	public BlockRubraciumChest(String name) 
 	{
 		super(Material.IRON);
+		setTranslationKey(name);
 		setRegistryName(name);
 		setCreativeTab(MetallurgyTabs.tabSpecial);
 		setHardness(6.0f);

--- a/src/main/java/krelox/metallurgychests/blocks/BlockSilverChest.java
+++ b/src/main/java/krelox/metallurgychests/blocks/BlockSilverChest.java
@@ -48,6 +48,7 @@ public class BlockSilverChest extends BlockContainer
 	public BlockSilverChest(String name) 
 	{
 		super(Material.IRON);
+		setTranslationKey(name);
 		setRegistryName(name);
 		setCreativeTab(MetallurgyTabs.tabSpecial);
 		setHardness(6.0f);


### PR DESCRIPTION
Sorry, I missed the renaming of this method between the old MCP snapshot and the current MCP release. This fixes the mod's chests having missing names.